### PR TITLE
Simple admin permissions

### DIFF
--- a/alembic/versions/cdbd433a9d78_add_simple_admin_to_user.py
+++ b/alembic/versions/cdbd433a9d78_add_simple_admin_to_user.py
@@ -1,0 +1,26 @@
+"""add simple admin to user
+
+Revision ID: cdbd433a9d78
+Revises: c4cd6daf947e
+Create Date: 2017-01-20 18:32:38.761785
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'cdbd433a9d78'
+down_revision = 'c4cd6daf947e'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.add_column(sa.Column('admin', sa.Boolean))
+
+def downgrade():
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.drop_column('admin')
+

--- a/src/data/models/user.py
+++ b/src/data/models/user.py
@@ -19,10 +19,15 @@ class User(Base, CRUDMixin):
 
 #see flask-login changelog 0.3.0: "is_authenticated" et al are now properties, 
 #not methods because fuck your backwards compatibility (paraphrased)
-
-    is_authenticated = True
-    is_active = True
-    is_anonymous = False
+    @property
+    def is_authenticated(self):
+        return True
+    @property
+    def is_active(self):
+        return True
+    @property
+    def is_anonymous(self):
+        return False
 
 #I guess this should also be a property, but ehhh    
     def is_admin(self):

--- a/src/data/models/user.py
+++ b/src/data/models/user.py
@@ -1,7 +1,7 @@
 import bcrypt
 
 from sqlalchemy.schema import Column
-from sqlalchemy.types import Integer, String, DateTime
+from sqlalchemy.types import Integer, String, DateTime, Boolean
 
 from ..base import Base
 from ..mixins import CRUDMixin
@@ -15,15 +15,18 @@ class User(Base, CRUDMixin):
     salt = Column('salt', String())
     email = Column('email', String(50), unique=True, index=True)
     created_at = Column('created_at', DateTime)
+    admin = Column('admin', Boolean, default = False)
 
-    def is_authenticated(self):
-        return True
+#see flask-login changelog 0.3.0: "is_authenticated" et al are now properties, 
+#not methods because fuck your backwards compatibility (paraphrased)
 
-    def is_active(self):
-        return True
+    is_authenticated = True
+    is_active = True
+    is_anonymous = False
 
-    def is_anonymous(self):
-        return False
+#I guess this should also be a property, but ehhh    
+    def is_admin(self):
+        return self.admin
 
     def get_id(self):
         return unicode(self.id)

--- a/src/data/prepopulate.py
+++ b/src/data/prepopulate.py
@@ -18,8 +18,18 @@ def prepopulate_database():
         password=hashed_pw,
         salt=salt,
         email='example@example.com',
-        created_at=datetime.datetime.utcnow()
+        created_at=datetime.datetime.utcnow(),
+        admin = True
     )
+    normal_user = User.create(
+        username='tilted_painting',
+        password=hashed_pw,
+        salt=salt,
+        email='example@example.example',
+        created_at=datetime.datetime.utcnow(),
+        admin = False
+    )
+
 
     test_game = Game.create(name='Test Game', developer='Test Dev')
     brave_earth = Game.create(name='Brave Earth: Epilogue', developer='Not Kayin')

--- a/src/test/test_admin.py
+++ b/src/test/test_admin.py
@@ -1,0 +1,38 @@
+import pytest
+import bcrypt
+
+from flask import url_for
+from src.data.models import User
+from src.data.db import db as _db
+
+def setup_module(cls):
+    salt = bcrypt.gensalt()
+    hashed_pw = bcrypt.hashpw('password', salt)
+    user = User.create(username='test_admin', password=hashed_pw, email='admin@example.example', salt=salt, admin = True)
+    user2 = User.create(username='test_rando', password=hashed_pw, email='rando@example.example', salt=salt, admin = False)
+
+
+def teardown_module(cls):
+    _db.session.query(User).filter_by(username='test_admin').delete()
+    _db.session.query(User).filter_by(username='test_rando').delete()
+    _db.session.commit()
+
+def test_show_admin_index(client):
+    res = client.get(url_for('admin.index'))
+    assert res.status_code == 200
+
+def test_admin_fails_while_anon(client):
+    res = client.get(url_for('challengeadmin.index_view'))
+    assert res.status_code == 302
+    assert 'login' in res.location
+
+def test_admin_fails_while_not_admin(client):
+    client.post(url_for('login.show'), data=dict(username='test_rando', password='password'))
+    res = client.get(url_for('challengeadmin.index_view'))
+    assert res.status_code == 302
+    assert 'login' in res.location
+
+def test_admin_succeeds_while_admin(client):
+    client.post(url_for('login.show'), data=dict(username='test_admin', password='password'))
+    res = client.get(url_for('challengeadmin.index_view'))
+    assert res.status_code == 200

--- a/src/web/__init__.py
+++ b/src/web/__init__.py
@@ -74,12 +74,13 @@ def create_app(app_config):
 
     login_manager.login_view = 'login.show'
 
-    admin.add_view(AdminModelView(Challenge, db.session))
+    admin.add_view(AdminModelView(Challenge, db.session, endpoint='challengeadmin'))
     admin.add_view(AdminModelView(Game, db.session))
     admin.add_view(AdminModelView(MarathonInfo, db.session))
     admin.add_view(AdminModelView(Prize, db.session))
     admin.add_view(AdminModelView(Interview, db.session))
     admin.add_view(AdminModelView(ScheduleEntry, db.session))
+    admin.add_view(AdminModelView(User, db.session))
     admin.add_view(ImageView(Image, db.session))
 
     login_manager.init_app(app)
@@ -110,7 +111,9 @@ class AdminModelView(ModelView):
     column_hide_backrefs = False
 
     def is_accessible(self):
-        return current_user.is_authenticated
+        if not current_user.is_anonymous:
+            return current_user.is_admin()
+        return False
 
     def inaccessible_callback(self, name, **kwargs):
         # redirect to login page if user doesn't have access


### PR DESCRIPTION
Puts the admin control panel behind an admin flag on accounts. 

Also updates the User model "is_authenticated", "is_active", and "is_anonymous" to be compliant with flask-login 0.3.0 changing them to properties. Was that necessary? Hell if I know, but trying to access the admin panel as an anonymous user just errors out otherwise.